### PR TITLE
Amzlinux2

### DIFF
--- a/attributes/sysctl.rb
+++ b/attributes/sysctl.rb
@@ -95,7 +95,7 @@ default['sysctl']['params']['net']['ipv6']['conf']['default']['accept_ra'] = 0
 case node['platform_family']
 when 'rhel', 'fedora'
   # on RHEL 7 its enabled per default and can't be disabled
-  if node['platform_version'].to_f < 7
+  if node['platform_version'].to_f < 7 && node['platform'] != 'amazon'
     default['sysctl']['params']['kernel']['exec-shield'] = 1
   end
 end

--- a/recipes/pam.rb
+++ b/recipes/pam.rb
@@ -102,7 +102,7 @@ when 'rhel', 'fedora'
   # therefore we edit /etc/pam.d/system-auth-ac/
   # @see http://serverfault.com/questions/292406/puppet-configuration-using-augeas-fails-if-combined-with-notify
 
-  if node['platform_version'].to_f < 7
+  if node['platform_version'].to_f < 7 && node['platform'] != 'amazon'
     # remove pam_cracklib, because it does not play nice with passwdqc in versions less than 7
     package 'pam-cracklib' do
       package_name node['os-hardening']['packages']['pam_cracklib']


### PR DESCRIPTION
amazon is listed in the rhel family (for some reason even though it has diverged quite a bit)
amazon linux does not have  exec-shield